### PR TITLE
Virtio bug fix with new paging code

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -189,7 +189,6 @@ fn qemu_run_image_x86_64(b: *Builder, image_path: []const u8) *std.build.RunStep
         "-no-shutdown",
         "-machine", "q35",
         "-device", "qemu-xhci",
-        "-cpu", "qemu64"
         //"-smp", "8",
         //"-cpu", "host", "-enable-kvm",
         //"-d", "int",

--- a/build.zig
+++ b/build.zig
@@ -189,7 +189,7 @@ fn qemu_run_image_x86_64(b: *Builder, image_path: []const u8) *std.build.RunStep
         "-no-shutdown",
         "-machine", "q35",
         "-device", "qemu-xhci",
-        "-cpu", "qemu64,+la57"
+        "-cpu", "qemu64"
         //"-smp", "8",
         //"-cpu", "host", "-enable-kvm",
         //"-d", "int",


### PR DESCRIPTION
To fix the problem, I changed the virtio-pci queue allocation code to not assume a physically contiguous heap anymore, but then I still got random memory corruption.
After playing around a bit more, I found that disabling 5-level paging fixed the issue (maybe a qemu bug?).