### PR TITLE
x86_64: Spirous interrupt fixes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -189,7 +189,7 @@ fn qemu_run_image_x86_64(b: *Builder, image_path: []const u8) *std.build.RunStep
         "-machine", "q35",
         "-device", "qemu-xhci",
         "-smp", "8",
-        //"-cpu", "host", "-enable-kvm",
+        "-cpu", "host", "-enable-kvm",
         //"-d", "int",
         //"-s", "-S",
         //"-trace", "ahci_*",

--- a/src/platform/x86_64/pic.zig
+++ b/src/platform/x86_64/pic.zig
@@ -1,16 +1,29 @@
 const ports = @import("ports.zig");
 
+fn wait() void {
+  asm volatile("outb %%al, $0x80" : : [_]"{al}"(@as(u8, 0)) : "memory");
+}
+
 pub fn disable() void {
   // Remmapping PIC
   ports.outb(0x20, 0x11);
+  wait();
   ports.outb(0xa0, 0x11);
+  wait();
   ports.outb(0x21, 0x20);
+  wait();
   ports.outb(0xa1, 0x28);
+  wait();
   ports.outb(0x21, 0b0000_0100);
+  wait();
   ports.outb(0xa1, 0b0000_0010);
+  wait();
   ports.outb(0x21, 0x01);
+  wait();
   ports.outb(0xa1, 0x01);
+  wait();
   // Masking out all PIC interrupts
   ports.outb(0x21, 0xFF);
   ports.outb(0xa1, 0xFF);
+  wait();
 }

--- a/src/platform/x86_64/x86_64.zig
+++ b/src/platform/x86_64/x86_64.zig
@@ -44,7 +44,7 @@ pub fn platform_early_init() void {
   os.platform.smp.cpus[0].platform_data.gdt.load();
   os.memory.paging.init();
 
-  set_interrupts(true);
+  //set_interrupts(true);
 }
 
 pub fn ap_init() void {


### PR DESCRIPTION
This PR does the following

- [x] Changes `build.zig` file to run Florence in KVM on x86_64. KVM usually has a more accurate emulation of interrupts, for example, it allowed us to detect issues with spurious IRQs
- [x] Add wait() calls in PIC disable routine. Without those wait calls, the PIC can be remapped incorrectly (and it's often the case in KVM).
- [x] Don't enable interrupts. LAPIC is enabled in limine and we are getting spurious interrupts because of that. We need to make sure to initialize LAPIC properly first before enabling interrupts. For that, we would need a LAPIC driver by @StaticSaga that is not there yet.