### PR TITLE
x86_64: Drain PS/2 keyboard buffer on init

### DIFF
--- a/src/platform/x86_64/ps2.zig
+++ b/src/platform/x86_64/ps2.zig
@@ -74,8 +74,10 @@ fn kb_wait_byte() u8 {
   return ports.inb(0x60);
 }
 
-pub fn kb_handler(_: *os.platform.InterruptFrame) void {
+fn handle_keyboard_interrupt() void {
   var ext: Extendedness = .NotExtended;
+
+  if(!kb_has_byte()) return;
 
   var scancode = kb_wait_byte();
 
@@ -89,8 +91,15 @@ pub fn kb_handler(_: *os.platform.InterruptFrame) void {
   eoi();
 }
 
-pub fn kb_init() void {
+pub fn kb_handler(_: *os.platform.InterruptFrame) void {
+  handle_keyboard_interrupt();
+}
 
+pub fn kb_init() void {
+  const i = os.platform.get_and_disable_interrupts();
+  defer os.platform.set_interrupts(i);
+
+  handle_keyboard_interrupt();
 }
 
 fn key_location(ext: Extendedness, scancode: u8) !kb.keys.Location {

--- a/src/platform/x86_64/x86_64.zig
+++ b/src/platform/x86_64/x86_64.zig
@@ -63,7 +63,6 @@ pub fn platform_init() !void {
 
   if(comptime(os.config.kernel.x86_64.ps2.enable_keyboard)) {
     const ps2 = @import("ps2.zig");
-    ps2.kb_init();
     ps2.kb_interrupt_vector = interrupts.allocate_vector();
     os.log("PS2 keyboard: vector 0x{X}\n", .{ps2.kb_interrupt_vector});
 
@@ -71,6 +70,7 @@ pub fn platform_init() !void {
 
     ps2.kb_interrupt_gsi = apic.route_irq(0, 1, ps2.kb_interrupt_vector);
     os.log("PS2 keyboard: gsi 0x{X}\n", .{ps2.kb_interrupt_gsi});
+    ps2.kb_init();
   }
 
   try os.platform.pci.init_pci();


### PR DESCRIPTION
This makes it so that we actually get interrupts when you type
in case you've been typing before we route the interrupt and the
controller is stuck waiting for us