### PR TITLE
Single consumer condvar

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -212,7 +212,7 @@ fn qemu_run_image_x86_64(b: *Builder, image_path: []const u8) *std.build.RunStep
         "-no-shutdown",
         "-machine", "q35",
         "-device", "qemu-xhci",
-        "-smp", "8",
+        "-smp", "2",
         "-cpu", "host", "-enable-kvm",
         //"-d", "int",
         //"-s", "-S",

--- a/build.zig
+++ b/build.zig
@@ -212,7 +212,7 @@ fn qemu_run_image_x86_64(b: *Builder, image_path: []const u8) *std.build.RunStep
         "-no-shutdown",
         "-machine", "q35",
         "-device", "qemu-xhci",
-        "-smp", "2",
+        "-smp", "8",
         "-cpu", "host", "-enable-kvm",
         //"-d", "int",
         //"-s", "-S",

--- a/src/boot/stivale2.zig
+++ b/src/boot/stivale2.zig
@@ -178,6 +178,8 @@ fn smp_entry(info_in: u64) callconv(.C) noreturn {
 
   cpu.booted = true;
   platform.ap_init();
+
+  cpu.bootstrap_tasking();
 }
 
 export fn stivale2_main(info_in: *stivale2_info) noreturn {

--- a/src/platform/aarch64/aarch64.zig
+++ b/src/platform/aarch64/aarch64.zig
@@ -56,20 +56,7 @@ pub fn ap_init() noreturn {
 
   interrupts.set_interrupt_stack(cpu.int_stack);
 
-  asm volatile(
-    \\BR %[dest]
-    :
-    : [stack] "{SP}" (cpu.sched_stack)
-    , [dest] "r" (ap_init_stage2)
-  );
-  unreachable;
-}
-
-fn ap_init_stage2() noreturn {
-  _ = @atomicRmw(usize, &os.platform.smp.cpus_left, .Sub, 1, .AcqRel);
-  // Wait for tasks
-  asm volatile("SVC #'B'");
-  unreachable;
+  cpu.bootstrap_tasking();
 }
 
 pub fn clock() usize {

--- a/src/platform/aarch64/aarch64.zig
+++ b/src/platform/aarch64/aarch64.zig
@@ -48,15 +48,13 @@ pub fn platform_init() !void {
   try os.platform.pci.init_pci();
 }
 
-pub fn ap_init() noreturn {
+pub fn ap_init() void {
   os.memory.paging.kernel_context.apply();
   interrupts.install_vector_table();
 
   const cpu = os.platform.thread.get_current_cpu();
 
   interrupts.set_interrupt_stack(cpu.int_stack);
-
-  cpu.bootstrap_tasking();
 }
 
 pub fn clock() usize {

--- a/src/platform/aarch64/interrupts.zig
+++ b/src/platform/aarch64/interrupts.zig
@@ -279,7 +279,6 @@ export fn interrupt_handler(frame: *InterruptFrame) void {
       switch(@truncate(u16, iss)) {
         else => @panic("Unknown SVC"),
 
-        'B' => os.thread.preemption.bootstrap(frame),
         'S' => do_stack_call(frame),
       }
     },

--- a/src/platform/aarch64/interrupts.zig
+++ b/src/platform/aarch64/interrupts.zig
@@ -241,8 +241,8 @@ pub fn install_vector_table() void {
 }
 
 fn do_stack_call(frame: *InterruptFrame) void {
-  const fun = @intToPtr(fn (*os.platform.InterruptFrame, usize) void, frame.x0);
-  const ctx: usize = frame.x1;
+  const fun = @intToPtr(fn (*os.platform.InterruptFrame, usize) void, frame.x8);
+  const ctx: usize = frame.x9;
   fun(frame, ctx);
 }
 

--- a/src/platform/aarch64/interrupts.zig
+++ b/src/platform/aarch64/interrupts.zig
@@ -274,7 +274,11 @@ export fn interrupt_handler(frame: *InterruptFrame) void {
         else => @panic("Unknown SVC"),
 
         'B' => os.thread.preemption.bootstrap(frame),
-        'Y' => os.thread.preemption.wait_yield(frame),
+        'Y' => {
+            const fun = @intToPtr(fn (*os.platform.InterruptFrame, usize) void, frame.x0);
+            const ctx: usize = frame.x1;
+            fun(frame, ctx);
+        }
       }
     },
   }

--- a/src/platform/aarch64/thread.zig
+++ b/src/platform/aarch64/thread.zig
@@ -29,7 +29,7 @@ pub const TaskData = struct {
 
 pub fn sched_call_impl(fun: usize, ctx: usize) void {
   asm volatile(
-    \\SVC #'Y'
+    \\SVC #'S'
     :
     : [_]"{X0}"(fun),
       [_]"{X1}"(ctx),

--- a/src/platform/aarch64/thread.zig
+++ b/src/platform/aarch64/thread.zig
@@ -31,8 +31,8 @@ pub fn sched_call_impl(fun: usize, ctx: usize) void {
   asm volatile(
     \\SVC #'S'
     :
-    : [_]"{X0}"(fun),
-      [_]"{X1}"(ctx),
+    : [_]"{X8}"(fun),
+      [_]"{X9}"(ctx),
   );
 }
 

--- a/src/platform/aarch64/thread.zig
+++ b/src/platform/aarch64/thread.zig
@@ -27,8 +27,13 @@ pub const TaskData = struct {
   }
 };
 
-pub fn yield() void {
-  asm volatile("SVC #'Y'");
+pub fn sched_call_impl(fun: usize, ctx: usize) void {
+  asm volatile(
+    \\SVC #'Y'
+    :
+    : [_]"{X0}"(fun),
+      [_]"{X1}"(ctx),
+  );
 }
 
 pub fn init_task_call(new_task: *os.thread.Task, entry: *os.thread.NewTaskEntry) !void {

--- a/src/platform/platform.zig
+++ b/src/platform/platform.zig
@@ -154,3 +154,10 @@ pub const PhysBytes = struct {
   ptr: usize,
   len: usize,
 };
+
+/// Helper for calling functions on scheduler stack
+pub fn sched_call(fun: fn (*os.platform.InterruptFrame, usize) void, ctx: usize) void {
+    const state = os.platform.get_and_disable_interrupts();
+    os.platform.thread.sched_call_impl(@ptrToInt(fun), ctx);
+    os.platform.set_interrupts(state);
+}

--- a/src/platform/x86_64/interrupts.zig
+++ b/src/platform/x86_64/interrupts.zig
@@ -24,7 +24,6 @@ pub fn add_handler(idx: u8, f: InterruptHandler, interrupt: bool, priv_level: u2
   handlers[idx] = f;
 }
 
-pub const boostrap_vector: u8 = 0x30;
 pub const sched_call_vector: u8 = 0x31;
 pub const syscall_vector: u8 = 0x32;
 pub const spurious_vector: u8 = 0x3F;
@@ -45,7 +44,6 @@ pub fn init_interrupts() void {
   }
 
   add_handler(0x0E,              page_fault_handler, true, 3, 1);
-  add_handler(boostrap_vector,   os.thread.preemption.bootstrap, true, 0, 0);
   add_handler(sched_call_vector, os.platform.thread.sched_call_impl_handler, true, 0, 2);
   add_handler(spurious_vector,   spurious_handler, true, 0, 1);
 }

--- a/src/platform/x86_64/interrupts.zig
+++ b/src/platform/x86_64/interrupts.zig
@@ -25,7 +25,7 @@ pub fn add_handler(idx: u8, f: InterruptHandler, interrupt: bool, priv_level: u2
 }
 
 pub const boostrap_vector: u8 = 0x30;
-pub const wait_yield_vector: u8 = 0x31;
+pub const sched_call_vector: u8 = 0x31;
 pub const syscall_vector: u8 = 0x32;
 pub const spurious_vector: u8 = 0x3F;
 
@@ -46,7 +46,7 @@ pub fn init_interrupts() void {
 
   add_handler(0x0E,              page_fault_handler, true, 3, 1);
   add_handler(boostrap_vector,   os.thread.preemption.bootstrap, true, 0, 0);
-  add_handler(wait_yield_vector, os.thread.preemption.wait_yield, true, 0, 2);
+  add_handler(sched_call_vector, os.platform.thread.sched_call_impl_handler, true, 0, 2);
   add_handler(spurious_vector,   spurious_handler, true, 0, 1);
 }
 

--- a/src/platform/x86_64/thread.zig
+++ b/src/platform/x86_64/thread.zig
@@ -30,6 +30,8 @@ pub const TaskData = struct {
 
 pub const CoreData = struct {
   gdt: gdt.Gdt = .{},
+  shared_tss: Tss = .{},
+  shared_tss_loaded: bool = true,
   rsp_stash: u64 = undefined, // Stash for rsp after syscall instruction
   lapic: ?os.platform.phys_ptr(*volatile [0x100]u32) = undefined,
 };

--- a/src/platform/x86_64/x86_64.zig
+++ b/src/platform/x86_64/x86_64.zig
@@ -79,14 +79,15 @@ pub fn platform_init() !void {
 pub fn platform_early_init() void {
   // Set SMP metadata for the first CPU
   os.platform.smp.prepare();
-  // Init serial
+
   serial.init();
+
   // Load IDT
   interrupts.init_interrupts();
-  const cpu = &os.platform.smp.cpus[0];
+
   // Init BSP GDT
-  cpu.platform_data.gdt.load();
-  // Init paging
+  os.platform.smp.cpus[0].platform_data.gdt.load();
+
   os.memory.paging.init();
 }
 
@@ -112,7 +113,7 @@ pub fn bsp_pre_scheduler_init() void {
   cpu.platform_data.gdt.update_tss(&cpu.platform_data.shared_tss);
 }
 
-pub fn ap_init() noreturn {
+pub fn ap_init() void {
   os.memory.paging.kernel_context.apply();
   idt.load_idt();
   setup_syscall_instr();
@@ -125,8 +126,6 @@ pub fn ap_init() noreturn {
   cpu.platform_data.shared_tss.set_interrupt_stack(cpu.int_stack);
   cpu.platform_data.shared_tss.set_scheduler_stack(cpu.sched_stack);
   cpu.platform_data.gdt.update_tss(&cpu.platform_data.shared_tss);
-
-  cpu.bootstrap_tasking();
 }
 
 pub fn spin_hint() void {

--- a/src/platform/x86_64/x86_64.zig
+++ b/src/platform/x86_64/x86_64.zig
@@ -63,14 +63,16 @@ pub fn platform_init() !void {
 
   if(comptime(os.config.kernel.x86_64.ps2.enable_keyboard)) {
     const ps2 = @import("ps2.zig");
-    ps2.interrupt_vector = interrupts.allocate_vector();
-    os.log("PS2: vector 0x{X}\n", .{ps2.interrupt_vector});
+    ps2.kb_interrupt_vector = interrupts.allocate_vector();
+    os.log("PS2 keyboard: vector 0x{X}\n", .{ps2.kb_interrupt_vector});
 
-    interrupts.add_handler(ps2.interrupt_vector, ps2.handler, true, 3, 1);
+    interrupts.add_handler(ps2.kb_interrupt_vector, ps2.kb_handler, true, 3, 1);
 
-    ps2.interrupt_gsi = apic.route_irq(0, 0x01, ps2.interrupt_vector);
-    os.log("PS2: gsi 0x{X}\n", .{ps2.interrupt_gsi});
+    ps2.kb_interrupt_gsi = apic.route_irq(0, 1, ps2.kb_interrupt_vector);
+    os.log("PS2 keyboard: gsi 0x{X}\n", .{ps2.kb_interrupt_gsi});
+    ps2.kb_init();
   }
+
   try os.platform.pci.init_pci();
 }
 

--- a/src/thread/preemption.zig
+++ b/src/thread/preemption.zig
@@ -1,11 +1,16 @@
 const os = @import("root").os;
 
-/// Switch to the next task from the current one
-fn yield_to(frame: *os.platform.InterruptFrame, task: *os.thread.Task) void {
+/// Store state of the current thread
+pub fn store_current_state(frame: *os.platform.InterruptFrame) void {
+    const current_task = os.platform.get_current_task();
+    current_task.registers = frame.*;
+}
+
+/// Load state of the task. In other words, prepare the core to run the task
+fn load_state(frame: *os.platform.InterruptFrame, task: *os.thread.Task) void {
     const cpu = os.platform.thread.get_current_cpu();
     const current_task = os.platform.get_current_task();
 
-    current_task.registers = frame.*;
     frame.* = task.registers;
     os.platform.set_current_task(task);
     if (current_task.paging_context != task.paging_context) {
@@ -15,21 +20,20 @@ fn yield_to(frame: *os.platform.InterruptFrame, task: *os.thread.Task) void {
     task.platform_data.load_state();
 }
 
+/// Await for the next task to come to the core and yield to it
+pub fn await_task_and_yield(frame: *os.platform.InterruptFrame) void {
+    const cpu = os.platform.thread.get_current_cpu();
+    load_state(frame, cpu.executable_tasks.dequeue());
+}
+
 /// Yield to the next task or stay in the same task
 /// if there is no next task. Use in timers
 pub fn yield_or_not(frame: *os.platform.InterruptFrame) void {
+    preserve_state(frame);
     const cpu = os.platform.thread.get_current_cpu();
     if (cpu.executable_tasks.try_dequeue()) |task| {
-        yield_to(frame, task);
+        load_state(frame, task);
     }
-}
-
-/// Wait for queue to become non-empty and yield to the next task
-/// Use for yield. Empty usize argument is needed so that
-/// this function could be passed to os.platform.sched_call
-pub fn wait_yield(frame: *os.platform.InterruptFrame, _: usize) void {
-    const cpu = os.platform.thread.get_current_cpu();
-    yield_to(frame, cpu.executable_tasks.dequeue());
 }
 
 /// Wait for the task on bootstrap

--- a/src/thread/preemption.zig
+++ b/src/thread/preemption.zig
@@ -25,8 +25,9 @@ pub fn yield_or_not(frame: *os.platform.InterruptFrame) void {
 }
 
 /// Wait for queue to become non-empty and yield to the next task
-/// Use for yield
-pub fn wait_yield(frame: *os.platform.InterruptFrame) void {
+/// Use for yield. Empty usize argument is needed so that
+/// this function could be passed to os.platform.sched_call
+pub fn wait_yield(frame: *os.platform.InterruptFrame, _: usize) void {
     const cpu = os.platform.thread.get_current_cpu();
     yield_to(frame, cpu.executable_tasks.dequeue());
 }

--- a/src/thread/preemption.zig
+++ b/src/thread/preemption.zig
@@ -35,13 +35,3 @@ pub fn yield_or_not(frame: *os.platform.InterruptFrame) void {
         load_state(frame, task);
     }
 }
-
-/// Wait for the task on bootstrap
-pub fn bootstrap(frame: *os.platform.InterruptFrame) void {
-    const cpu = os.platform.thread.get_current_cpu();
-    const task = cpu.executable_tasks.dequeue();
-    frame.* = task.registers;
-    task.paging_context.apply();
-    os.platform.set_current_task(task);
-    task.platform_data.load_state();
-}

--- a/src/thread/scheduler.zig
+++ b/src/thread/scheduler.zig
@@ -12,94 +12,94 @@ var balancer_lock = os.thread.Spinlock{};
 /// NOTE: Should be called in interrupt disabled context if its
 /// not the last time task runs
 pub fn wait() void {
-  os.platform.thread.yield();
+    os.platform.sched_call(os.thread.preemption.wait_yield, undefined);
 }
 
 /// Terminate current task to never run it again
 pub fn leave() noreturn {
-  wait();
-  unreachable;
+    wait();
+    unreachable;
 }
 
 /// Preempt to the next task
 pub fn yield() void {
-  const state = os.platform.get_and_disable_interrupts();
-  os.platform.thread.get_current_cpu().executable_tasks.enqueue(os.platform.get_current_task());
-  os.platform.thread.yield();
-  os.platform.set_interrupts(state);
+    const state = os.platform.get_and_disable_interrupts();
+    os.platform.thread.get_current_cpu().executable_tasks.enqueue(os.platform.get_current_task());
+    wait();
+    os.platform.set_interrupts(state);
 }
 
 /// Wake a task that has called `wait`
 pub fn wake(task: *os.thread.Task) void {
-  os.platform.smp.cpus[task.allocated_core_id].executable_tasks.enqueue(task);
+    os.platform.smp.cpus[task.allocated_core_id].executable_tasks.enqueue(task);
 }
 
 /// Create a new task that calls a function with given arguments.
 /// Uses heap, so don't create tasks in interrupt context
 pub fn make_task(func: anytype, args: anytype) !*os.thread.Task {
-  const task = try task_alloc.create(os.thread.Task);
-  errdefer task_alloc.destroy(task);
+    const task = try task_alloc.create(os.thread.Task);
+    errdefer task_alloc.destroy(task);
 
-  try task.allocate_stack();
-  errdefer task.free_stack();
+    try task.allocate_stack();
+    errdefer task.free_stack();
 
-  task.paging_context = os.platform.get_current_task().paging_context;
-  // Find the best CPU for the task
-  var best_cpu_idx: usize = 0;
-  {
-    const state = balancer_lock.lock();
-    // TODO: maybe something more sophisticated?
-    for (os.platform.smp.cpus) |*cpu, i| {
-      if (cpu.tasks_count < os.platform.smp.cpus[best_cpu_idx].tasks_count) {
-        best_cpu_idx = i;
-      }
+    task.paging_context = os.platform.get_current_task().paging_context;
+    // Find the best CPU for the task
+    var best_cpu_idx: usize = 0;
+    {
+        const state = balancer_lock.lock();
+        // TODO: maybe something more sophisticated?
+        for (os.platform.smp.cpus) |*cpu, i| {
+            if (cpu.tasks_count < os.platform.smp.cpus[best_cpu_idx].tasks_count) {
+                best_cpu_idx = i;
+            }
+        }
+        task.allocated_core_id = best_cpu_idx;
+        os.platform.smp.cpus[best_cpu_idx].tasks_count += 1;
+        balancer_lock.unlock(state);
     }
-    task.allocated_core_id = best_cpu_idx;
-    os.platform.smp.cpus[best_cpu_idx].tasks_count += 1;
-    balancer_lock.unlock(state);
-  }
 
-  os.log("Task allocated to core {}\n", .{best_cpu_idx});
+    os.log("Task allocated to core {}\n", .{best_cpu_idx});
 
-  errdefer {
-    const state = balancer_lock.lock();
-    os.platform.smp.cpus[best_cpu_idx].tasks_count -= 1;
-    balancer_lock.unlock(state);
-  }
+    errdefer {
+        const state = balancer_lock.lock();
+        os.platform.smp.cpus[best_cpu_idx].tasks_count -= 1;
+        balancer_lock.unlock(state);
+    }
 
-  // Initialize task in a way that it will execute func with args on the startup
-  const entry = os.thread.NewTaskEntry.alloc(task, func, args);
-  try os.platform.thread.init_task_call(task, entry);
-  return task;
+    // Initialize task in a way that it will execute func with args on the startup
+    const entry = os.thread.NewTaskEntry.alloc(task, func, args);
+    try os.platform.thread.init_task_call(task, entry);
+    return task;
 }
 
 /// Create and start a new task that calls a function with given arguments.
 pub fn spawn_task(func: anytype, args: anytype) !void {
-  const task = try make_task(func, args);
-  os.platform.smp.cpus[task.allocated_core_id].executable_tasks.enqueue(task);
+    const task = try make_task(func, args);
+    os.platform.smp.cpus[task.allocated_core_id].executable_tasks.enqueue(task);
 }
 
 /// Exit current task
 /// TODO: Should be reimplemented with URM
 pub fn exit_task() noreturn {
-  const task = os.platform.thread.self_exited();
-  const id = if (task) |t| t.allocated_core_id else 0;
+    const task = os.platform.thread.self_exited();
+    const id = if (task) |t| t.allocated_core_id else 0;
 
-  const state = balancer_lock.lock();
-  os.platform.smp.cpus[id].tasks_count -= 1;
-  balancer_lock.unlock(state);
+    const state = balancer_lock.lock();
+    os.platform.smp.cpus[id].tasks_count -= 1;
+    balancer_lock.unlock(state);
 
-  if(task) |t| {
-    task_alloc.destroy(t);
-  }
+    if (task) |t| {
+        task_alloc.destroy(t);
+    }
 
-  leave();
+    leave();
 }
 
 /// Initialize scheduler
 pub fn init(task: *os.thread.Task) void {
-  os.platform.smp.cpus[0].bootstrap_stacks();
-  os.platform.bsp_pre_scheduler_init();
-  os.platform.set_current_task(task);
-  os.platform.thread.get_current_cpu().executable_tasks.init();
+    os.platform.smp.cpus[0].bootstrap_stacks();
+    os.platform.bsp_pre_scheduler_init();
+    os.platform.set_current_task(task);
+    os.platform.thread.get_current_cpu().executable_tasks.init();
 }

--- a/src/thread/single_listener.zig
+++ b/src/thread/single_listener.zig
@@ -54,7 +54,7 @@ pub const SingleListener = struct {
                 os.thread.preemption.store_current_state(frame);
                 //os.log("Current state preserved!\n", .{});
                 // Enable wakeup. After this point, task can be enqueued any minute
-                @atomicStore(bool, &listener.wakeup_allowed, true, .Release);
+                @atomicStore(bool, &listener.wakeup_allowed, true, .SeqCst);
                 // Check if there are any events
                 if (listener.diff() != 0) {
                     // If there are some events, we race with trigger()

--- a/src/thread/task_entry.zig
+++ b/src/thread/task_entry.zig
@@ -18,10 +18,15 @@ pub const NewTaskEntry = struct {
             function: Func,
             args: Args,
 
+            /// Error guard
+            fn calL_with_error_guard(self: *@This()) !void {
+                return @call(.{}, self.function, self.args);
+            }
+
             /// Implementation of invoke
             fn invoke(entry: *NewTaskEntry) noreturn {
                 const self = @fieldParentPtr(@This(), "entry", entry);
-                @call(.{}, self.function, self.args) catch |err| {
+                self.calL_with_error_guard() catch |err| {
                     os.log("Task has finished with error {s}\n", .{@errorName(err)});
                 };
                 os.thread.scheduler.exit_task();


### PR DESCRIPTION
This PR adds `os.platform.sched_call` method that allows to run any function `fn (*os.platform.InterruptFrame, usize)` on the stack. It also makes `yield` and `wait` scheduler functions use that to preempt between threads. In addition, this method properly implements single-consumer condvar used in kepler code, fixing https://github.com/FlorenceOS/Florence/issues/43