### PR TITLE
Resolve stage2 compiler error in bitfields lib

### DIFF
--- a/lib/util/bitfields.zig
+++ b/lib/util/bitfields.zig
@@ -14,7 +14,7 @@ fn PtrCastPreserveCV(comptime T: type, comptime PtrToT: type, comptime NewT: typ
 fn BitType(comptime FieldType: type, comptime ValueType: type, comptime shamt: usize) type {
     const self_bit: FieldType = (1 << shamt);
 
-    return struct {
+    return extern struct {
         bits: Bitfield(FieldType, shamt, 1),
 
         pub fn set(self: anytype) void {
@@ -58,7 +58,7 @@ pub fn Bitfield(comptime FieldType: type, comptime shamt: usize, comptime num_bi
 
     const ValueType = std.meta.Int(.unsigned, num_bits);
 
-    return struct {
+    return extern struct {
         dummy: FieldType,
 
         fn field(self: anytype) PtrCastPreserveCV(@This(), @TypeOf(self), FieldType) {


### PR DESCRIPTION
This pull request conerns a small change I had to make in order to use FlorenceOS's bitfield utility library on Zig's stage2 compiler. 


In stage2, the compiler rejects what used to be valid code with the following error: 
```
zba on  main [!] via ↯
❯ zig build run
C:\Users\paoda\Documents\dev\proj\zba\src\core\bus\io.zig:469:5: error: extern unions cannot contain fields of type 'bitfield.Bitfield(u16,0,8)'
    x2: Bitfield(u16, 0, 8),
    ^~~~~~~~~~~~~~~~~~~~~~~
C:\Users\paoda\Documents\dev\proj\zba\src\core\bus\io.zig:469:5: note: only structs with packed or extern layout are extern compatible
C:\Users\paoda\Documents\dev\proj\zba\lib\util\bitfield.zig:66:12: note: struct declared here
    return struct {
           ^~~~~~
```

This PR replaces both examples of `return struct` with `return extern struct`. This works for both stage1 and stage2. 